### PR TITLE
Load data by team

### DIFF
--- a/components/DataContainer.jsx
+++ b/components/DataContainer.jsx
@@ -1,5 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
+import _ from "lodash";
 import TeamBlock from "./TeamBlock";
 import ProjectDetail from "./ProjectDetail";
 
@@ -30,6 +31,16 @@ class DataContainer extends React.Component {
   /* 
   HANDLE DATA FILTERING AND SEARCH
   */
+
+  groupProjectsByTeam(projects) {
+    return _.groupBy(projects, project => {
+      try {
+        return project["Team Submitted"];
+      } catch (e) {
+        return ("No team identified");
+      }
+    });
+  }
 
   handleTeamChange(o) {
     this.setState({ activeTeam: o });
@@ -91,8 +102,11 @@ class DataContainer extends React.Component {
   }
 
   render() {
-    const teams = ["Boulder", "Chicago", "Dallas", "Latin America"];
     const projects = this.state.projects;
+    
+    const groupedTeam = this.groupProjectsByTeam(projects);
+    const teams = Object.keys(groupedTeam);
+    console.log(teams);
     const teamProjects = this.filterProjectsByTeam(
       projects,
       this.state.activeTeam
@@ -120,7 +134,10 @@ class DataContainer extends React.Component {
         ) : (
           <div className="content-grid">
             {/* Visuals */}
-            <div className="visuals-detail">Visuals</div>
+            <div className="visuals-detail">
+            Visuals
+            {/* <div>{groupedTeam}</div> */}
+            </div>
             <div className="teams-detail">
               {/* Teams */}
               {teams.map(team => {

--- a/components/DataContainer.jsx
+++ b/components/DataContainer.jsx
@@ -143,15 +143,14 @@ class DataContainer extends React.Component {
             {/* Visuals */}
             <div className="visuals-detail">
             Visuals
-            {/* <div>{groupedTeam}</div> */}
             </div>
             <div className="teams-detail">
               {/* Teams */}
               {teams.map(team => {
                 const tprojects = projects.filter(
                   project =>
-                    project["Office Submitted"] &&
-                    project["Office Submitted"].includes(team)
+                    project["Team Submitted"] &&
+                    project["Team Submitted"].includes(team)
                 );
                 return (
                   <TeamBlock

--- a/components/FilterBar.jsx
+++ b/components/FilterBar.jsx
@@ -32,7 +32,7 @@ class FilterBar extends React.Component {
   }
 
   render() {
-    const filterTypes = ["Outstanding", "Open", "In Closing", "Closed"];
+    const filterTypes = ["Outstanding", "Won", "Lost", "Open", "In Closing", "Closed"];
     const searchTerm = this.props.searchTerm;
     const filterParam = this.props.filterParam;
 

--- a/components/TeamBlock.jsx
+++ b/components/TeamBlock.jsx
@@ -1,30 +1,16 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
+import PropTypes from 'prop-types';
 import _ from 'lodash';
-import Chart from 'chart.js';
-import ProjectDetail from './ProjectDetail';
-import utils from '../helpers/utils';
 
-const BarChart = require('react-chartjs').Bar;
+import ProjectDetail from './ProjectDetail';
+
+import utils from '../helpers/utils';
 
 class TeamBlock extends React.Component {
   constructor(props) {
     super(props);
 
-    this.state = {
-      statusGroups: {},
-      statusCalc: true
-    }
-
     this.handleTeamChange = this.handleTeamChange.bind(this);
-  };
-
-  // on mount, save status report to state
-  componentDidMount() {
-    const projects = this.props.projects;
-    const statusGroups = this.groupProjectsByStatus(projects);
-    this.setState({statusGroups});
-    this.setState({statusCalc: false});
   };
 
   handleTeamChange() {
@@ -35,19 +21,20 @@ class TeamBlock extends React.Component {
     }
   };
 
-  groupProjectsByStatus(projects) {
-    return _.groupBy(projects, project => {
-      return project["Status Update?"];
-    });
+  returnArrOfMgrs(records) {
+    let arr = [];
+    records.forEach(r => {
+      try {
+        arr = [...arr, ...r["PM Submitted"]];
+      } catch (e) {}
+    })
+    return arr;
   };
 
  render() {
-    const calcPerc = utils.calcPerc;
-    
     const projects = this.props.projects;
-    // const projectCount = projects.length;
-
-    const status = this.state.statusGroups;
+    const pms = this.returnArrOfMgrs(projects);
+    const uniquePms = _.uniq(pms);
 
     const activeStyle = {
       border: '2px solid lightblue',
@@ -65,30 +52,16 @@ class TeamBlock extends React.Component {
         style={this.props.activeteam ? activeStyle : inactiveStyle }
         >
         <h3>{this.props.team}</h3>
-        {/* {this.state.statusCalc
-        ? <p>Chart Loading</p>
-        : <BarChart data={statusData} />} */}
-        <div className="team-graph__detail">
-          {/* <p>Total: {projects.length}</p> */}
-          {this.state.statusCalc
-          ? <p><strong>Loading Report</strong></p>
-          : <p>
-            {/* Open: {status['undefined'].length} | {calcPerc((status['undefined'].length), (projectCount))} */}
-            <br/>
-            {/* On Hold: {status['On Hold'].length} | {calcPerc((status['On Hold'].length), (projectCount))} */}
-            <br/>
-            {/* Contract Negotiation: {status['Contract Negotiation'].length} | {calcPerc((status['Contract Negotiation'].length), (projectCount))} */}
-            <br/>
-            {/* Closed: {status['Closed Won'].length + status['Closed Lost'].length} | {calcPerc((status['Closed Won'].length + status['Closed Lost'].length), (projectCount))}               */}
-            <br/>
-            {/* Win Rate: {calcPerc((status['Closed Won'].length), (projectCount))} */}
-            <br/> 
-            {/* Lose Rate: {calcPerc((status['Closed Lost'].length), (projectCount))} */}
-            </p>}
-        </div>
+        <ul>
+          {uniquePms.map(pm => <li>{pm}</li>)}
+        </ul>
       </div>
     )
   }
 }
+
+TeamBlock.propTypes = {
+  projects: PropTypes.array
+};
 
 module.exports = TeamBlock;

--- a/components/TeamBlock.jsx
+++ b/components/TeamBlock.jsx
@@ -45,7 +45,7 @@ class TeamBlock extends React.Component {
     const calcPerc = utils.calcPerc;
     
     const projects = this.props.projects;
-    const projectCount = projects.length;
+    // const projectCount = projects.length;
 
     const status = this.state.statusGroups;
 
@@ -69,21 +69,21 @@ class TeamBlock extends React.Component {
         ? <p>Chart Loading</p>
         : <BarChart data={statusData} />} */}
         <div className="team-graph__detail">
-          <p>Total: {projects.length}</p>
+          {/* <p>Total: {projects.length}</p> */}
           {this.state.statusCalc
           ? <p><strong>Loading Report</strong></p>
           : <p>
-            Open: {status['undefined'].length} | {calcPerc((status['undefined'].length), (projectCount))}
+            {/* Open: {status['undefined'].length} | {calcPerc((status['undefined'].length), (projectCount))} */}
             <br/>
-            On Hold: {status['On Hold'].length} | {calcPerc((status['On Hold'].length), (projectCount))}
+            {/* On Hold: {status['On Hold'].length} | {calcPerc((status['On Hold'].length), (projectCount))} */}
             <br/>
-            Contract Negotiation: {status['Contract Negotiation'].length} | {calcPerc((status['Contract Negotiation'].length), (projectCount))}
+            {/* Contract Negotiation: {status['Contract Negotiation'].length} | {calcPerc((status['Contract Negotiation'].length), (projectCount))} */}
             <br/>
-            Closed: {status['Closed Won'].length + status['Closed Lost'].length} | {calcPerc((status['Closed Won'].length + status['Closed Lost'].length), (projectCount))}              
+            {/* Closed: {status['Closed Won'].length + status['Closed Lost'].length} | {calcPerc((status['Closed Won'].length + status['Closed Lost'].length), (projectCount))}               */}
             <br/>
-            Win Rate: {calcPerc((status['Closed Won'].length), (projectCount))}
+            {/* Win Rate: {calcPerc((status['Closed Won'].length), (projectCount))} */}
             <br/> 
-            Lose Rate: {calcPerc((status['Closed Lost'].length), (projectCount))}
+            {/* Lose Rate: {calcPerc((status['Closed Lost'].length), (projectCount))} */}
             </p>}
         </div>
       </div>


### PR DESCRIPTION
Passes team-specific projects, rather than office-specific projects to TeamBlock components. Displays list of Project Managers within each TeamBlock. Cleans up TeamBlock component to remove unneeded graph and analysis code. Adds PropType checking to TeamBlock component.